### PR TITLE
Modded Brush Compatibility

### DIFF
--- a/src/main/java/io/github/itskilerluc/familiarfaces/server/entities/Armadillo.java
+++ b/src/main/java/io/github/itskilerluc/familiarfaces/server/entities/Armadillo.java
@@ -30,6 +30,7 @@ import net.minecraft.world.entity.ai.goal.WrappedGoal;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.BrushItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.Level;
@@ -326,7 +327,7 @@ public class Armadillo extends Animal {
     @Override
     public InteractionResult mobInteract(Player player, InteractionHand hand) {
         ItemStack itemstack = player.getItemInHand(hand);
-        if (itemstack.is(Items.BRUSH) && this.brushOffScute()) {
+        if (itemstack.getItem() instanceof BrushItem && this.brushOffScute()) {
             itemstack.hurtAndBreak(16, player, e -> {
             });
             return InteractionResult.sidedSuccess(this.level().isClientSide);


### PR DESCRIPTION
This small change allows brushes added by other mods to harvest Scute from the Armadillo, such as the brushes from [More Brushes](https://www.curseforge.com/minecraft/mc-mods/more-brushes/files/all).

People are requesting compatibility on some of my other mods, figured the best fix is to this is from the source.